### PR TITLE
Go revolution

### DIFF
--- a/internal/astutil/indents.go
+++ b/internal/astutil/indents.go
@@ -14,3 +14,19 @@ func GetRootIdent(expr ast.Expr) *ast.Ident {
 		return nil
 	}
 }
+
+func IsValidIdent(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !IsValidIdentRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func IsValidIdentRune(r rune) bool {
+	return r == '_' || r == '$' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}

--- a/internal/astutil/strings.go
+++ b/internal/astutil/strings.go
@@ -1,0 +1,108 @@
+package astutil
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"unicode"
+)
+
+func DetectStringLikeConst(vs *ast.ValueSpec, ctx *TranspileContext) bool {
+	if vs.Type != nil {
+		if tv, ok := ctx.GetTypes()[vs.Type]; ok && tv.Type != nil {
+			// Verifica se é alias de string
+			if named, ok := tv.Type.(*types.Named); ok {
+				if named.String() != "string" && tv.Type.Underlying().String() == "string" {
+					return true
+				}
+			}
+			// Ou string puro
+			if tv.Type.Underlying().String() == "string" {
+				return true
+			}
+		}
+	}
+
+	// Se não tem tipo explícito, mas tem valor literal string
+	if len(vs.Values) > 0 {
+		if bl, ok := vs.Values[0].(*ast.BasicLit); ok && bl.Kind == token.STRING {
+			return false
+		}
+	}
+
+	return false
+}
+
+func IsAllCaps(name string) bool {
+	if name == "" {
+		return false
+	}
+	hasLetter := false
+	for _, r := range name {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+			if !unicode.IsUpper(r) {
+				return false
+			}
+		}
+	}
+	return hasLetter
+}
+
+func IsAllLower(name string) bool {
+	if name == "" {
+		return false
+	}
+	hasLetter := false
+	for _, r := range name {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+			if !unicode.IsLower(r) {
+				return false
+			}
+		}
+	}
+	return hasLetter
+}
+
+func IsConstant(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' {
+			return false
+		}
+	}
+	return true
+}
+
+func IsIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if i == 0 && !unicode.IsLetter(r) {
+			return false
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' {
+			return false
+		}
+	}
+	return true
+}
+
+func IsVar(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if i == 0 && !unicode.IsLetter(r) {
+			return false
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to string literal obfuscation and identifier validation in the codebase. The changes add new utility functions for string and identifier analysis, and improve the `StringObfuscatePass` logic to better handle string constants, struct tags, and import paths during obfuscation. The overall result is a more robust and flexible string obfuscation pass, with improved handling of various edge cases.

### String obfuscation logic improvements

* The `StringObfuscatePass` in `internal/pass/string_obfuscate_pass.go` now distinguishes between string constants, struct tags, and import paths, obfuscating only appropriate string literals and converting certain constants to variables or initializing them in an `init` function for better runtime handling.
* The obfuscation pass avoids obfuscating strings that are common Go keywords, struct tags, or import paths, and introduces logic to handle string-like constants, including alias types and uninitialized constants.

### String and identifier analysis utilities

* Added new utility functions in `internal/astutil/strings.go` for analyzing string names, such as `IsAllCaps`, `IsAllLower`, `IsConstant`, `IsIdentifier`, and `IsVar`, as well as logic to detect string-like constants via type analysis.
* Introduced `IsValidIdent` and `IsValidIdentRune` functions in `internal/astutil/indents.go` to validate identifier names and their constituent runes, improving identifier handling throughout the codebase.